### PR TITLE
Adds 'workflow_dispatch' to enable manual trigger of GitHub Action.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,6 +8,11 @@ on:
     branches: [ $default-branch ]
   pull_request:
     branches: [ $default-branch ]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        required: false
+        default: 'debug'
 
 permissions:
   contents: read


### PR DESCRIPTION
I followed documentation:

- GitHub Docs. [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
- GitHub Docs. [Events that trigger workflows: workflow_dispatch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch)